### PR TITLE
Add a sanity test meant to be run after CI.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -138,12 +138,12 @@ fn add_msvc_arg(cmd: &mut Command) -> Result<&mut Command, Box<Error>> {
     Ok(cmd)
 }
 #[cfg(not(target_env = "msvc"))]
-fn add_msvc_arg(cmd: &mut Command) -> Result<&mut Command, Box<Error>> {
+fn add_msvc_arg(cmd: &mut Command) -> Result<&mut Command, Box<dyn Error>> {
     Ok(cmd)
 }
 
 /// Build script entry point
-fn main() -> Result<(), Box<Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     #[cfg(target_env = "msvc")]
     return Ok(());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,3 +44,23 @@ pub mod xed_version {
     #[cfg(not(target_env = "msvc"))]
     include!(concat!(env!("OUT_DIR"), "/xed_version.rs"));
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_xed_get_copyright() {
+        let version = unsafe {
+            std::ffi::CStr::from_ptr(xed_version::xed_get_copyright())
+                .to_string_lossy()
+                .to_string()
+        };
+
+        assert_eq!(
+            "Copyright (C) 2017, Intel Corporation. All rights reserved.",
+            &version
+        );
+    }
+
+}


### PR DESCRIPTION
Just a sanity test meant to be run after CI.

This test doesn't test any meaningful library functionality, it's just to make sure the bindings are working.

Idea based on https://rust-lang.github.io/rust-bindgen/tutorial-5.html.